### PR TITLE
FUJ-1311: pull additional issue fields from Jira

### DIFF
--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -145,7 +145,34 @@
             "displayName": {"type": [ "null", "string"] },
             "accountId": {"type": [ "null", "string"] } 
           }
-        }
+        },
+        "summary": {
+          "type": [
+            "null",  "string"
+          ]
+        },
+        "labels": {
+          "type": [ "null",  "array" ],
+            "items": {
+    			"type": "string"
+ 		 	}		
+        },
+        "components": {
+           "type": [ "null",  "array" ],
+           "items": {
+           		"type": [ "null", "object"],
+           		"properties": {
+		            "name": {"type": [ "null", "string"] }   			
+           		}
+           }
+        },
+        "customfield_10021": {
+           "$comment": "Sprints are defined as custom fields in Jira, so the custom field id could be different for different instances",
+           "type": [ "null",  "array" ],
+           "items": {
+            "$ref": "sprint"
+          }
+        }        
       },
       "patternProperties": {
         ".+": {}
@@ -307,6 +334,15 @@
           ]
         }
       }
+    },
+    "sprint": {           		
+    	"type": ["null", "object" ],
+    	"properties": {
+		 	"name": {"type": [ "null", "string"] },   			
+       		"startDate": { "type": [ "null", "string" ], "format": "date-time" },
+       		"endDate": { "type": [ "null", "string" ], "format": "date-time" },
+       		"completeDate": { "type": [ "null", "string" ], "format": "date-time" }
+        }
     },
     "attachment": {
       "properties": {


### PR DESCRIPTION
Note that the specific custom field id for sprint varies by JIra cloud instance, so this schema end up being specific to Pathlight's setup rather than generalizable.

The custom field contents are currently pulled as a json field rather than individual fields; we may want to change this for latter but it's probably fine to start with:

[{"id": 24, "goal": "", "name": "Sprint 116", "state": "closed", "boardId": 6, "endDate": "2022-01-29T06:10:00.000Z", "startDate": "2022-01-18T22:24:44.859Z", "completeDate": "2022-01-31T17:28:11.459Z"}]