### PR TITLE
Enable API token Basic Authorization for JIRA

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -17,17 +17,27 @@ REQUIRED_CONFIG_KEYS_CLOUD = ["start_date",
                               "refresh_token",
                               "oauth_client_id",
                               "oauth_client_secret"]
+# Note: password authentication has been deprecated
+# https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
 REQUIRED_CONFIG_KEYS_HOSTED = ["start_date",
                                "username",
                                "password",
                                "base_url",
                                "user_agent"]
+REQUIRED_CONFIG_KEYS_HOSTED_TOKEN = ["start_date",
+                                     "username",
+                                     "api_token",
+                                     "base_url",
+                                     "user_agent"]
 
 
 def get_args():
     unchecked_args = utils.parse_args([])
     if 'username' in unchecked_args.config.keys():
-        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED)
+        if 'api_token' in unchecked_args.config.keys():
+            return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED_TOKEN)
+        else:
+            return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED)
 
     return utils.parse_args(REQUIRED_CONFIG_KEYS_CLOUD)
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -166,8 +166,14 @@ class Client():
             self.test_credentials_are_authorized()
         else:
             LOGGER.info("Using Basic Auth API authentication")
+            credentials = None
+            if config.get("api_token"):
+                credentials = config.get("api_token")
+            else:
+                LOGGER.info("Warning: using deprecated password authentication")
+                credentials = config.get("password")
+            self.auth = HTTPBasicAuth(config.get("username"), credentials)
             self.base_url = config.get("base_url")
-            self.auth = HTTPBasicAuth(config.get("username"), config.get("password"))
             self.test_basic_credentials_are_authorized()
 
     def url(self, path):


### PR DESCRIPTION
Previously we were using username and password Basic Authorization for the JIRA API calls. However, this has now been deprecated so we should switch to using API token based authentication.

https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/

I created a new API token here: https://id.atlassian.com/manage-profile/security/api-tokens

Then I ran the JIRA tap locally and it works correctly.
